### PR TITLE
Not using the highest version on numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ argparse>=1.4.0
 requests>=2.25.1
 pyyaml>=5.4.1
 python-jenkins>=1.7.0
-numpy>=1.22.4
+numpy<2
 elasticsearch<7.14.0
 coloredlogs>=15.0.1
 utils


### PR DESCRIPTION
For some time all [jobs](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/post-results-to-es/) were failing because numpy version jumped over ES requirements.
We can try to using newer version of ES - but this should work.