### PR TITLE
Replace prod-netobserv-jenkins-metadata index with perf_scale_ci* index

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -793,7 +793,7 @@ pipeline {
                 withCredentials([usernamePassword(credentialsId: 'elasticsearch-perfscale-ocp-qe', usernameVariable: 'ES_USERNAME', passwordVariable: 'ES_PASSWORD')]) {
                     script {
                         // construct arguments for NOPE tool and execute
-                        NOPE_ARGS = "--starttime $STARTDATEUNIXTIMESTAMP --endtime $ENDDATEUNIXTIMESTAMP --jenkins-job $WORKLOAD_JENKINS_JOB --jenkins-build $JENKINS_BUILD --uuid ${env.UUID}"
+                        NOPE_ARGS = "--starttime $STARTDATEUNIXTIMESTAMP --endtime $ENDDATEUNIXTIMESTAMP --uuid ${env.UUID}"
                         if ("${NOO_BUNDLE_VERSION}" != 'null'){
                             echo "NOO_BUNDLE_VERSION: ${NOO_BUNDLE_VERSION}"
                             NOPE_ARGS += " --noo-bundle-version ${NOO_BUNDLE_VERSION}"

--- a/scripts/queries/netobserv_touchstone_statistics_config.json
+++ b/scripts/queries/netobserv_touchstone_statistics_config.json
@@ -26,13 +26,10 @@
                     "metric_name"
                 ]
             },
-            "prod-netobserv-jenkins-metadata": {
+            "perf_scale_ci*": {
                 "fields": [
                     "buildUrl",
-                    "jenkins_build_num",
-                    "jenkins_job_name",
-                    "variable",
-                    "workload"
+                    "benchmark"
                 ],
                 "additional_fields": [
                     "metric_name"

--- a/scripts/queries/netobserv_touchstone_tolerancy_config.json
+++ b/scripts/queries/netobserv_touchstone_tolerancy_config.json
@@ -25,12 +25,10 @@
                     "metric_name"
                 ]
             },
-            "prod-netobserv-jenkins-metadata": {
+            "perf_scale_ci*": {
                 "fields": [
-                    "jenkins_build_num",
-                    "jenkins_job_name",
-                    "variable",
-                    "workload"
+                    "buildUrl",
+                    "benchmark"
                 ],
                 "additional_fields": [
                     "metric_name"


### PR DESCRIPTION
Prow performance test job won't use `prod-netobserv-jenkins-metadata`, we faced an error when prow job failed to upload the baseline as the workload data is not found in `prod-netobserv-jenkins-metadata` ES index. 
```
+ python nope.py baseline --upload 7ead7670-93b7-4149-b4bf-fc70e02e6c78
�[32m2025-04-09 04:27:43�[0m �[35mnode-density-heavy-25nodes-netobserv-perf-test-metrics-upload�[0m �[34mroot[632]�[0m �[1;30mINFO�[0m Got netobserv-operator.v0.0.0-main for release from test results for UUID 7ead7670-93b7-4149-b4bf-fc70e02e6c78
�[32m2025-04-09 04:27:43�[0m �[35mnode-density-heavy-25nodes-netobserv-perf-test-metrics-upload�[0m �[34mroot[632]�[0m �[1;30mERROR�[0m �[31mGot 0 hits - should be '1'�[0m
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:84","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.internalRun","level":"error","msg":"Error executing test process","severity":"error","time":"2025-04-09T04:27:43Z"}

```
faced above error during [rehearsal](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/62759/rehearse-62759-periodic-ci-openshift-eng-ocp-qe-perfscale-ci-netobserv-perf-tests-netobserv-aws-4.19-nightly-x86-node-density-heavy-25nodes/1909781769125629952) 

Workload data already exists in `perf_scale_ci*` so use that instead , this is also compatible with current jenkins job where data already exists. Also, cleaning up to remove jenkinsEnv data entirely.