### PR TITLE
NETOBSERV-2128 Dockerfile for Prow CI and don't print token at info level

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,0 +1,7 @@
+FROM registry.ci.openshift.org/ci/opm-builder:latest as opm-builder
+FROM registry.ci.openshift.org/ci/ocp-qe-perfscale-ci:latest
+COPY --from=opm-builder /bin/opm /usr/bin/opm
+COPY scripts scripts
+ENV HOME=/home/user
+RUN mkdir -p /home/user && curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && unzip awscli-bundle.zip && awscli-bundle/install -b $HOME/bin/aws
+ENV PATH="$PATH:$HOME/bin"

--- a/scripts/nope.py
+++ b/scripts/nope.py
@@ -794,7 +794,7 @@ if __name__ == "__main__":
             "No token could be found - ensure all the Prerequisite steps in the README were followed"
         )
         sys.exit(1)
-    logging.info(f"TOKEN: {TOKEN}")
+    logging.debug(f"TOKEN: {TOKEN}")
 
     # determine if data will be dumped locally or uploaded to Elasticsearch
     DUMP_ONLY = args.dump_only


### PR DESCRIPTION
[NETOBSERV-2128](https://issues.redhat.com//browse/NETOBSERV-2128) This would help avoiding image building during the run and would be readily available. Also, don't bring token as it is likely the cause of logs being removed entirely in CI run, for [example](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/62759/rehearse-62759-periodic-ci-openshift-eng-ocp-qe-perfscale-ci-netobserv-perf-tests-netobserv-aws-4.19-nightly-x86-cluster-density-v2-250nodes/1910713106590339072/artifacts/cluster-density-v2-250nodes/netobserv-perf-test-metrics-upload/build-log.txt)