### PR TITLE
NETOBSERV-2226 Create and share spreadsheets

### DIFF
--- a/scripts/sheets/sheets.py
+++ b/scripts/sheets/sheets.py
@@ -1,26 +1,86 @@
 import google.oauth2.service_account
 import apiclient.discovery
 from googleapiclient.errors import HttpError
+from googleapiclient.discovery import build
+import logging
+
+logger = logging.getLogger("perfsheets")
 
 
 class Sheets:
-    _Scopes_Read_Only = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
-    _Scopes_Read_Write = ["https://www.googleapis.com/auth/spreadsheets"]
-
     def __init__(self, sheetid, cell_range, service_account_file):
         self.sheetid = sheetid
         self.service_account = service_account_file
         self.cell_range = cell_range
 
     def _get_sheets_service(self, read_only: bool = False):
-        scopes = Sheets._Scopes_Read_Only if read_only else Sheets._Scopes_Read_Write
-        credentials = (
+        scopes = [
+            "https://www.googleapis.com/auth/spreadsheets",
+            "https://www.googleapis.com/auth/drive",
+        ]
+
+        self.credentials = (
             google.oauth2.service_account.Credentials.from_service_account_file(
                 str(self.service_account),
                 scopes=scopes,
             )
         )
-        return apiclient.discovery.build("sheets", "v4", credentials=credentials)
+        return apiclient.discovery.build("sheets", "v4", credentials=self.credentials)
+
+    def create(self, title):
+        """Create a spreadsheet with title"""
+        spreadsheet = {"properties": {"title": title}}
+        try:
+            spreadsheet = (
+                self._get_sheets_service()
+                .spreadsheets()
+                .create(body=spreadsheet, fields="spreadsheetId")
+                .execute()
+            )
+            logger.info(f"Spreadsheet ID: {(spreadsheet.get('spreadsheetId'))}")
+            self.sheetid = spreadsheet.get("spreadsheetId")
+        except HttpError as error:
+            raise Exception(f"An error occurred while creating google sheet: {error}")
+
+    def create_permission(self, email):
+        """Adds write permissions for email user to the generated sheet"""
+
+        permission = {
+            "type": "user",
+            "role": "writer",
+            "emailAddress": email,
+        }
+
+        service = apiclient.discovery.build("drive", "v3", credentials=self.credentials)
+        try:
+            service.permissions().create(fileId=self.sheetid, body=permission).execute()
+        except HttpError as error:
+            raise Exception(
+                f"An error occurred while adding permissions to google sheet: {error}"
+            )
+
+    def auto_resize_columns(self):
+        """Resizes columns in a Google Sheet to fit the data."""
+        request_body = {
+            "requests": [
+                {
+                    "autoResizeDimensions": {
+                        "dimensions": {
+                            "sheetId": 0,
+                            "dimension": "COLUMNS",
+                            "startIndex": 0,
+                            "endIndex": 7,
+                        }
+                    }
+                }
+            ]
+        }
+        try:
+            self._get_sheets_service().spreadsheets().batchUpdate(
+                spreadsheetId=self.sheetid, body=request_body
+            ).execute()
+        except HttpError as error:
+            raise Exception(f"Resizing columns failed: {error}")
 
     def get_values(self) -> list[list]:
         """


### PR DESCRIPTION
With this change, we'd able to create and name spreadsheets as we like and no longer required to parse the e2e-benchmarking logs to update the sheets.

Generate comparison sheet:

```
$ ./noo_perfsheets_update.py --service-account memodi-perf-tests-tool-083ab166a2cc.json --csv-file /Users/memodi/Downloads/d2617789-d9bf-4a3d-a2f5-74972ac393fc_comparison.csv --name memodi-ndh-test2 --comparison
2025-05-01 16:48:09,185 __init__:49 INFO file_cache is only supported with oauth2client<4.0.0
2025-05-01 16:48:10,423 sheets:40 INFO Spreadsheet ID: 175DG6Pe-hbFMcXg5yQNAwhRhbOAob5eKIDu0d-JkL40
2025-05-01 16:48:10,593 base:270 INFO POST https://search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com:443/prod-netobserv-operator-metadata/_search [status:200 request:0.168s]
2025-05-01 16:48:10,709 base:270 INFO POST https://search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com:443/prod-netobserv-operator-metadata/_search [status:200 request:0.115s]
2025-05-01 16:48:10,712 __init__:49 INFO file_cache is only supported with oauth2client<4.0.0
2025-05-01 16:48:11,487 __init__:49 INFO file_cache is only supported with oauth2client<4.0.0
2025-05-01 16:48:12,362 __init__:49 INFO file_cache is only supported with oauth2client<4.0.0
2025-05-01 16:48:13,039 noo_perfsheets_update:148 INFO Successfully wrote to google sheet: https://docs.google.com/spreadsheets/d/175DG6Pe-hbFMcXg5yQNAwhRhbOAob5eKIDu0d-JkL40
```

Generate metrics sheet:
```
$ ./noo_perfsheets_update.py --service-account memodi-perf-tests-tool-083ab166a2cc.json --csv-file /Users/memodi/Downloads/d2617789-d9bf-4a3d-a2f5-74972ac393fc_metrics.csv --name memodi-ndh-test2-metrics
2025-05-01 16:48:41,159 __init__:49 INFO file_cache is only supported with oauth2client<4.0.0
2025-05-01 16:48:42,854 sheets:40 INFO Spreadsheet ID: 1Mj4NfZIT9m5BPu48MPWFx1KaNJysv4qfTAHdDVqrPLQ
2025-05-01 16:48:42,858 __init__:49 INFO file_cache is only supported with oauth2client<4.0.0
2025-05-01 16:48:43,785 __init__:49 INFO file_cache is only supported with oauth2client<4.0.0
2025-05-01 16:48:44,850 __init__:49 INFO file_cache is only supported with oauth2client<4.0.0
2025-05-01 16:48:45,829 noo_perfsheets_update:148 INFO Successfully wrote to google sheet: https://docs.google.com/spreadsheets/d/1Mj4NfZIT9m5BPu48MPWFx1KaNJysv4qfTAHdDVqrPLQ
```