### PR TITLE
Remove secondaryNetworksConfig for UDN

### DIFF
--- a/scripts/netobserv/flows_v1beta2_flowcollector.yaml
+++ b/scripts/netobserv/flows_v1beta2_flowcollector.yaml
@@ -35,12 +35,6 @@ objects:
           limits:
             memory: ${FLPMemoryLimit}
         advanced:
-          secondaryNetworks:
-            - index:
-                - MAC
-                - Interface
-                - IP
-              name: ovn-kubernetes
         kafkaConsumerReplicas: ${{KafkaConsumerReplicas}}
       kafka:
         address: kafka-cluster-kafka-bootstrap.netobserv


### PR DESCRIPTION
Post bug fix [NETOBSERV-2254](https://issues.redhat.com/browse/NETOBSERV-2254) we dont require secondary-network config to see CUDN/UDN name