### PR TITLE
Revert "Netobserv: track metrics cardinality (#760)"

### DIFF
--- a/scripts/queries/netobserv_prometheus_queries.yaml
+++ b/scripts/queries/netobserv_prometheus_queries.yaml
@@ -202,18 +202,6 @@
 - query: sum(container_memory_working_set_bytes{namespace="netobserv", container="", pod=~"kafka.*"})
   metricName: workingsetKafkaTotals
 
-######################
-# Prometheus metrics #
-######################
-
-# netobserv total metrics cardinality ingested in Prometheus
-- query: count({__name__=~"netobserv_.*"})
-  metricName: metricsCardinality
-
-# FLP metrics cardinality ingested in Prometheus
-- query: count({__name__=~"netobserv_.*",job="flowlogs-pipeline-prom"})
-  metricName: flpMetricsCardinality
-
 ###########################
 # Total metrics #
 ###########################

--- a/scripts/queries/netobserv_touchstone_statistics_config.json
+++ b/scripts/queries/netobserv_touchstone_statistics_config.json
@@ -840,32 +840,6 @@
             },
             {
                 "filter": {
-                    "metric_name.keyword": "metricsCardinality"
-                },
-                "buckets": [
-                    "metric_name.keyword"
-                ],
-                "aggregations": {
-                    "value": [
-                        "avg"
-                    ]
-                }
-            },
-            {
-                "filter": {
-                    "metric_name.keyword": "flpMetricsCardinality"
-                },
-                "buckets": [
-                    "metric_name.keyword"
-                ],
-                "aggregations": {
-                    "value": [
-                        "avg"
-                    ]
-                }
-            },
-            {
-                "filter": {
                     "metric_name.keyword": "TotalNetObservCPUUsage"
                 },
                 "buckets": [

--- a/scripts/queries/netobserv_touchstone_tolerancy_config.json
+++ b/scripts/queries/netobserv_touchstone_tolerancy_config.json
@@ -350,19 +350,6 @@
             },
             {
                 "filter": {
-                    "metric_name.keyword": "metricsCardinality"
-                },
-                "buckets": [
-                    "metric_name.keyword"
-                ],
-                "aggregations": {
-                    "value": [
-                        "avg"
-                    ]
-                }
-            },
-            {
-                "filter": {
                     "metric_name.keyword": "TotalNetObservCPUUsage"
                 },
                 "buckets": [

--- a/scripts/queries/netobserv_touchstone_tolerancy_rules.yaml
+++ b/scripts/queries/netobserv_touchstone_tolerancy_rules.yaml
@@ -61,9 +61,6 @@
 - json_path: ["metric_name", "rssPrometheusTotals", "metric_name", "*", "avg(value)"]
   tolerancy: 60
   max_failures: 0
-- json_path: ["metric_name", "metricsCardinality", "metric_name", "*", "avg(value)"]
-  tolerancy: 30
-  max_failures: 0
 # total usages
 - json_path: ["metric_name", "TotalNetObservCPUUsage", "metric_name", "*", "avg(value)"]
   tolerancy: 10


### PR DESCRIPTION
consistently seeing 504 error when we gather metrics cadirnality over thanos, here’s example: [https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-[…]ightly-x86-cluster-density-v2-250nodes/1934996244669665280](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-netobserv-perf-tests-netobserv-aws-4.19-nightly-x86-cluster-density-v2-250nodes/1934996244669665280)

https://redhat-internal.slack.com/archives/C02939DP5L5/p1750143418257989