### PR TITLE
Bump default value of JENKINS_AGENT_LABEL from oc411 to oc419

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,15 +64,13 @@ pipeline {
         )
         string(
             name: 'JENKINS_AGENT_LABEL',
-            defaultValue: 'oc411',
+            defaultValue: 'oc419',
             description:
             '''
             scale-ci-static: for static agent that is specific to scale-ci, useful when the jenkins dynamic agent isn't stable<br>
             4.y: oc4y || mac-installer || rhel8-installer-4y <br/>
-                e.g, for 4.8, use oc48 || mac-installer || rhel8-installer-48 <br/>
+                e.g, for 4.19, use oc419 || mac-installer || rhel8-installer-419 <br/>
             3.11: ansible-2.6 <br/>
-            3.9~3.10: ansible-2.4 <br/>
-            3.4~3.7: ansible-2.4-extra || ansible-2.3 <br/>
             '''
         )
         text(


### PR DESCRIPTION
OCP 4.11 reach end of life. We've stopped building image for oc411 in Jenkins CI.