### PR TITLE
NETOBSERV-2034  Netobserv orion configs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -177,4 +177,6 @@ orion cmd --config scripts/queries/netobserv-orion-node-density-heavy-ospst.yaml
 
 Note that orion config files with suffix `*-ospst.yaml` are custom to OpenSearch instance: https://opensearch-dashboard.app.intlab.redhat.com (VPN Required), credentials can be obtained from bitwarden.
 
+Set env var `export ES_SERVER='https://$ES_USERNAME:$ES_PASSWORD@opensearch.app.intlab.redhat.com'`
+
 Orion config files without `*-ospst.yaml` are for OpenSearch instance https://search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com/ , data here is only preserved for last 60 days and older data can be found on https://opensearch-dashboard.app.intlab.redhat.com

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -115,6 +115,7 @@ The Network Observability Prometheus and Elasticsearch tool, or NOPE, is a Pytho
 ```bash
 $ export ES_USERNAME=<elasticsearch username>
 $ export ES_PASSWORD=<elasticsearch password>
+$ export ES_SERVER=https://search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com
 ```
 4. Run the tool with `./scripts/nope.py`
 
@@ -157,3 +158,23 @@ where workloads UUIDs are:
 
 ## Performance comparison sheets update
 [noo_perfsheets_update.py](scripts/sheets/noo_perfsheets_update.py) is a tool to update the performance comparison sheets that are generated during the network observability performance testings runs which makes use of upstream tool [csv_gen.py](https://github.com/cloud-bulldozer/e2e-benchmarking/blob/master/utils/csv_gen.py). It  replaces the UUIDs with identifiable information and removes redundant rows from the initial generated sheet. To update the correct sheet it relies on [log line](https://github.com/cloud-bulldozer/e2e-benchmarking/blob/master/utils/csv_gen.py#L47) to fetch the sheet name in the Jenkins pipeline.
+
+## Change point detection and comparison with Orion:
+[Orion](https://github.com/cloud-bulldozer/orion/?tab=readme-ov-file#orion---cli-tool-to-find-regressions) is a tool aimed to detect the change point in the performance metrics across several past runs and aimed to replace touchstone
+
+To detech regressions and change point use `--hunter-analyze` algorithm and to compare 2 uuids, use `--cmr` algorithm, below are the example commands of both runs:
+
+## Compare 2 uuids with Orion:
+
+```bash
+orion cmd --config scripts/queries/netobserv-orion-node-density-heavy-ospst.yaml --uuid 4edb6734-f080-43f6-82ca-05b23e294d87 --baseline a2ff22ab-63cb-4aa2-a253-e9aaadc115a9 --cmr
+```
+
+## Detect a change point:
+```bash
+orion cmd --config scripts/queries/netobserv-orion-node-density-heavy-ospst.yaml --hunter-analyze --lookback 60d
+```
+
+Note that orion config files with suffix `*-ospst.yaml` are custom to OpenSearch instance: https://opensearch-dashboard.app.intlab.redhat.com (VPN Required), credentials can be obtained from bitwarden.
+
+Orion config files without `*-ospst.yaml` are for OpenSearch instance https://search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com/ , data here is only preserved for last 60 days and older data can be found on https://opensearch-dashboard.app.intlab.redhat.com

--- a/scripts/queries/netobserv-orion-cluster-density-v2-ospst.yaml
+++ b/scripts/queries/netobserv-orion-cluster-density-v2-ospst.yaml
@@ -1,12 +1,12 @@
 tests:
-  - name: netobserv-perf-node-density-heavy-{{ platform }}-{{ workers }}w
+  - name: netobserv-perf-node-density-heavy-AWS-{{ workers }}w
     index: ospst-perf-scale-ci*
     benchmarkIndex: ospst-prod-netobserv-datapoints*
     metadata:
       benchmark.keyword: cluster-density-v2
-      platform: {{ platform }}
+      platform: AWS
       workerNodesCount: {{ workers }}
-      ocpVersion: {{ version }}
+      ocpVersion: 4
       jobType: periodic
     metrics:
       - name: nFlowsProcessedTotals

--- a/scripts/queries/netobserv-orion-cluster-density-v2-ospst.yaml
+++ b/scripts/queries/netobserv-orion-cluster-density-v2-ospst.yaml
@@ -1,0 +1,255 @@
+tests:
+  - name: netobserv-perf-node-density-heavy-{{ platform }}-{{ workers }}w
+    index: ospst-perf-scale-ci*
+    benchmarkIndex: ospst-prod-netobserv-datapoints*
+    metadata:
+      benchmark.keyword: cluster-density-v2
+      platform: {{ platform }}
+      workerNodesCount: {{ workers }}
+      ocpVersion: {{ version }}
+      jobType: periodic
+    metrics:
+      - name: nFlowsProcessedTotals
+        metric_name: nFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_count
+          agg_type: max
+        # fail if 10% flows processed in either direction
+        direction: 0
+        threshold: 10
+      - name: nFlowsProcessedPerMinuteTotals
+        metric_name: nFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_per_min_count
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: nWorkloadFlowsProcessedTotals
+        metric_name: nWorkloadFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: workload_flows_count
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: nWorkloadBytesProcessedPerMinuteNetobserv
+        metric_name: nWorkloadBytesProcessedPerMinuteNetobserv
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: workload_flows_per_min_count
+          agg_type: avg
+        direction: 0
+        threshold: 10
+      - name: nFlowsErroredRatio
+        metric_name: nFlowsErroredRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_error_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: lokiRecordsWritten
+        metric_name: lokiRecordsWritten
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_records
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: ebpfFlowsDroppedRatio
+        metric_name: ebpfFlowsDroppedRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_flows_drop_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: ebpfRingBufferMapRatioTotals
+        metric_name: ebpfRingBufferMapRatioTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_ring_buffer_map_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: lokiRecordsDroppedRatio
+        metric_name: lokiRecordsDroppedRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_flow_drop_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: cpuFLPTotals
+        metric_name: cpuFLPTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: cpuEBPFTotals
+        metric_name: cpuEBPFTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: cpuLokiTotals
+        metric_name: cpuLokiTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: cpuKafkaTotals
+        metric_name: cpuKafkaTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: kafka_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: cpuPrometheusTotals
+        metric_name: cpuPrometheusTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: prometheus_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssFLPTotals
+        metric_name: rssFLPTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: rssEBPFTotals
+        metric_name: rssEBPFTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: rssLokiTotals
+        metric_name: rssLokiTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssKafkaTotals
+        metric_name: rssKafkaTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: kafka_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssPrometheusTotals
+        metric_name: rssPrometheusTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: prometheus_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetObservCPUUsage
+        metric_name: TotalNetObservCPUUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: TotalNetObservRSSUsage
+        metric_name: TotalNetObservRSSUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: TotalClusterCPUUsage
+        metric_name: TotalClusterCPUUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: cluster_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalClusterRSSUsage
+        metric_name: TotalClusterRSSUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: cluster_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetworkBytesOut
+        metric_name: TotalNetworkBytesOut
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: network_bytes_out
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetworkBytesIn
+        metric_name: TotalNetworkBytesIn
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: network_bytes_in
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: NetObservClusterCPUPercentUtil
+        metric_name: NetObservClusterCPUPercentUtil
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cluster_cpu_percent_util
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: NetObservClusterMemPercentUtil
+        metric_name: NetObservClusterMemPercentUtil
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cluster_mem_percent_util
+          agg_type: avg
+        direction: 1
+        threshold: 10

--- a/scripts/queries/netobserv-orion-cluster-density-v2.yaml
+++ b/scripts/queries/netobserv-orion-cluster-density-v2.yaml
@@ -1,0 +1,256 @@
+tests:
+  - name: netobserv-perf-node-density-heavy-{{ platform }}-{{ workers }}w
+    index: perf_scale_ci*
+    benchmarkIndex: prod-netobserv-datapoints*
+    metadata:
+      benchmark.keyword: cluster-density-v2
+      platform: {{ platform }}
+      buildUrl: {{ buildurl }}
+      workerNodesCount: {{ workers }}
+      ocpVersion: {{ version }}
+      jobType: periodic
+    metrics:
+      - name: nFlowsProcessedTotals
+        metric_name: nFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_count
+          agg_type: max
+        # fail if 10% flows processed in either direction
+        direction: 0
+        threshold: 10
+      - name: nFlowsProcessedPerMinuteTotals
+        metric_name: nFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_per_min_count
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: nWorkloadFlowsProcessedTotals
+        metric_name: nWorkloadFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: workload_flows_count
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: nWorkloadBytesProcessedPerMinuteNetobserv
+        metric_name: nWorkloadBytesProcessedPerMinuteNetobserv
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: workload_flows_per_min_count
+          agg_type: avg
+        direction: 0
+        threshold: 10
+      - name: nFlowsErroredRatio
+        metric_name: nFlowsErroredRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_error_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: lokiRecordsWritten
+        metric_name: lokiRecordsWritten
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_records
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: ebpfFlowsDroppedRatio
+        metric_name: ebpfFlowsDroppedRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_flows_drop_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: ebpfRingBufferMapRatioTotals
+        metric_name: ebpfRingBufferMapRatioTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_ring_buffer_map_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: lokiRecordsDroppedRatio
+        metric_name: lokiRecordsDroppedRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_flow_drop_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: cpuFLPTotals
+        metric_name: cpuFLPTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: cpuEBPFTotals
+        metric_name: cpuEBPFTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: cpuLokiTotals
+        metric_name: cpuLokiTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: cpuKafkaTotals
+        metric_name: cpuKafkaTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: kafka_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: cpuPrometheusTotals
+        metric_name: cpuPrometheusTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: prometheus_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssFLPTotals
+        metric_name: rssFLPTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: rssEBPFTotals
+        metric_name: rssEBPFTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: rssLokiTotals
+        metric_name: rssLokiTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssKafkaTotals
+        metric_name: rssKafkaTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: kafka_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssPrometheusTotals
+        metric_name: rssPrometheusTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: prometheus_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetObservCPUUsage
+        metric_name: TotalNetObservCPUUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: TotalNetObservRSSUsage
+        metric_name: TotalNetObservRSSUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: TotalClusterCPUUsage
+        metric_name: TotalClusterCPUUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: cluster_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalClusterRSSUsage
+        metric_name: TotalClusterRSSUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: cluster_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetworkBytesOut
+        metric_name: TotalNetworkBytesOut
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: network_bytes_out
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetworkBytesIn
+        metric_name: TotalNetworkBytesIn
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: network_bytes_in
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: NetObservClusterCPUPercentUtil
+        metric_name: NetObservClusterCPUPercentUtil
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cluster_cpu_percent_util
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: NetObservClusterMemPercentUtil
+        metric_name: NetObservClusterMemPercentUtil
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cluster_mem_percent_util
+          agg_type: avg
+        direction: 1
+        threshold: 10

--- a/scripts/queries/netobserv-orion-cluster-density-v2.yaml
+++ b/scripts/queries/netobserv-orion-cluster-density-v2.yaml
@@ -1,13 +1,12 @@
 tests:
-  - name: netobserv-perf-node-density-heavy-{{ platform }}-{{ workers }}w
+  - name: netobserv-perf-node-density-heavy-AWS-{{ workers }}w
     index: perf_scale_ci*
     benchmarkIndex: prod-netobserv-datapoints*
     metadata:
       benchmark.keyword: cluster-density-v2
-      platform: {{ platform }}
-      buildUrl: {{ buildurl }}
+      platform: AWS
       workerNodesCount: {{ workers }}
-      ocpVersion: {{ version }}
+      ocpVersion: 4
       jobType: periodic
     metrics:
       - name: nFlowsProcessedTotals

--- a/scripts/queries/netobserv-orion-node-density-heavy-ospst.yaml
+++ b/scripts/queries/netobserv-orion-node-density-heavy-ospst.yaml
@@ -1,13 +1,12 @@
 tests:
-  - name: netobserv-perf-node-density-heavy-{{ platform }}-{{ workers }}w
+  - name: netobserv-perf-node-density-heavy-AWS-{{ workers }}w
     index: ospst-perf-scale-ci*
     benchmarkIndex: ospst-prod-netobserv-datapoints*
     metadata:
       benchmark.keyword: node-density-heavy
-      platform: {{ platform }}
-      buildUrl: {{ buildurl }}
+      platform: AWS
       workerNodesCount: {{ workers }}
-      ocpVersion: {{ version }}
+      ocpVersion: 4
       jobType: periodic
     metrics:
       - name: nFlowsProcessedTotals

--- a/scripts/queries/netobserv-orion-node-density-heavy-ospst.yaml
+++ b/scripts/queries/netobserv-orion-node-density-heavy-ospst.yaml
@@ -1,0 +1,256 @@
+tests:
+  - name: netobserv-perf-node-density-heavy-{{ platform }}-{{ workers }}w
+    index: ospst-perf-scale-ci*
+    benchmarkIndex: ospst-prod-netobserv-datapoints*
+    metadata:
+      benchmark.keyword: node-density-heavy
+      platform: {{ platform }}
+      buildUrl: {{ buildurl }}
+      workerNodesCount: {{ workers }}
+      ocpVersion: {{ version }}
+      jobType: periodic
+    metrics:
+      - name: nFlowsProcessedTotals
+        metric_name: nFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_count
+          agg_type: max
+        # fail if 10% flows processed in either direction
+        direction: 0
+        threshold: 10
+      - name: nFlowsProcessedPerMinuteTotals
+        metric_name: nFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_per_min_count
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: nWorkloadFlowsProcessedTotals
+        metric_name: nWorkloadFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: workload_flows_count
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: nWorkloadBytesProcessedPerMinuteNetobserv
+        metric_name: nWorkloadBytesProcessedPerMinuteNetobserv
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: workload_flows_per_min_count
+          agg_type: avg
+        direction: 0
+        threshold: 10
+      - name: nFlowsErroredRatio
+        metric_name: nFlowsErroredRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_error_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: lokiRecordsWritten
+        metric_name: lokiRecordsWritten
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_records
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: ebpfFlowsDroppedRatio
+        metric_name: ebpfFlowsDroppedRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_flows_drop_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: ebpfRingBufferMapRatioTotals
+        metric_name: ebpfRingBufferMapRatioTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_ring_buffer_map_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: lokiRecordsDroppedRatio
+        metric_name: lokiRecordsDroppedRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_flow_drop_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: cpuFLPTotals
+        metric_name: cpuFLPTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: cpuEBPFTotals
+        metric_name: cpuEBPFTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: cpuLokiTotals
+        metric_name: cpuLokiTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: cpuKafkaTotals
+        metric_name: cpuKafkaTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: kafka_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: cpuPrometheusTotals
+        metric_name: cpuPrometheusTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: prometheus_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssFLPTotals
+        metric_name: rssFLPTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: rssEBPFTotals
+        metric_name: rssEBPFTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: rssLokiTotals
+        metric_name: rssLokiTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssKafkaTotals
+        metric_name: rssKafkaTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: kafka_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssPrometheusTotals
+        metric_name: rssPrometheusTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: prometheus_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetObservCPUUsage
+        metric_name: TotalNetObservCPUUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: TotalNetObservRSSUsage
+        metric_name: TotalNetObservRSSUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: TotalClusterCPUUsage
+        metric_name: TotalClusterCPUUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: cluster_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalClusterRSSUsage
+        metric_name: TotalClusterRSSUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: cluster_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetworkBytesOut
+        metric_name: TotalNetworkBytesOut
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: network_bytes_out
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetworkBytesIn
+        metric_name: TotalNetworkBytesIn
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: network_bytes_in
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: NetObservClusterCPUPercentUtil
+        metric_name: NetObservClusterCPUPercentUtil
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cluster_cpu_percent_util
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: NetObservClusterMemPercentUtil
+        metric_name: NetObservClusterMemPercentUtil
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cluster_mem_percent_util
+          agg_type: avg
+        direction: 1
+        threshold: 10

--- a/scripts/queries/netobserv-orion-node-density-heavy.yaml
+++ b/scripts/queries/netobserv-orion-node-density-heavy.yaml
@@ -1,0 +1,255 @@
+tests:
+  - name: netobserv-perf-node-density-heavy-{{ platform }}-{{ workers }}w
+    index: perf_scale_ci*
+    benchmarkIndex: prod-netobserv-datapoints*
+    metadata:
+      benchmark.keyword: node-density-heavy
+      platform: {{ platform }}
+      workerNodesCount: {{ workers }}
+      ocpVersion: {{ version }}
+      jobType: periodic
+    metrics:
+      - name: nFlowsProcessedTotals
+        metric_name: nFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_count
+          agg_type: max
+        # fail if 10% flows processed in either direction
+        direction: 0
+        threshold: 10
+      - name: nFlowsProcessedPerMinuteTotals
+        metric_name: nFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_per_min_count
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: nWorkloadFlowsProcessedTotals
+        metric_name: nWorkloadFlowsProcessedTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: workload_flows_count
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: nWorkloadBytesProcessedPerMinuteNetobserv
+        metric_name: nWorkloadBytesProcessedPerMinuteNetobserv
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: workload_flows_per_min_count
+          agg_type: avg
+        direction: 0
+        threshold: 10
+      - name: nFlowsErroredRatio
+        metric_name: nFlowsErroredRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flow_error_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: lokiRecordsWritten
+        metric_name: lokiRecordsWritten
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_records
+          agg_type: max
+        direction: 0
+        threshold: 10
+      - name: ebpfFlowsDroppedRatio
+        metric_name: ebpfFlowsDroppedRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_flows_drop_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: ebpfRingBufferMapRatioTotals
+        metric_name: ebpfRingBufferMapRatioTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_ring_buffer_map_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: lokiRecordsDroppedRatio
+        metric_name: lokiRecordsDroppedRatio
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_flow_drop_ratio
+          agg_type: avg
+        direction: 1
+        threshold: 5
+      - name: cpuFLPTotals
+        metric_name: cpuFLPTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: cpuEBPFTotals
+        metric_name: cpuEBPFTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: cpuLokiTotals
+        metric_name: cpuLokiTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: cpuKafkaTotals
+        metric_name: cpuKafkaTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: kafka_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: cpuPrometheusTotals
+        metric_name: cpuPrometheusTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: prometheus_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssFLPTotals
+        metric_name: rssFLPTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: rssEBPFTotals
+        metric_name: rssEBPFTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: ebpf_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: rssLokiTotals
+        metric_name: rssLokiTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: loki_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssKafkaTotals
+        metric_name: rssKafkaTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: kafka_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: rssPrometheusTotals
+        metric_name: rssPrometheusTotals
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: prometheus_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetObservCPUUsage
+        metric_name: TotalNetObservCPUUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: TotalNetObservRSSUsage
+        metric_name: TotalNetObservRSSUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_rss
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: TotalClusterCPUUsage
+        metric_name: TotalClusterCPUUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: cluster_cpu
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalClusterRSSUsage
+        metric_name: TotalClusterRSSUsage
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: cluster_rss
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetworkBytesOut
+        metric_name: TotalNetworkBytesOut
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: network_bytes_out
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: TotalNetworkBytesIn
+        metric_name: TotalNetworkBytesIn
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: network_bytes_in
+          agg_type: avg
+        direction: 1
+        threshold: 60
+      - name: NetObservClusterCPUPercentUtil
+        metric_name: NetObservClusterCPUPercentUtil
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cluster_cpu_percent_util
+          agg_type: avg
+        direction: 1
+        threshold: 10
+      - name: NetObservClusterMemPercentUtil
+        metric_name: NetObservClusterMemPercentUtil
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: netobserv_cluster_mem_percent_util
+          agg_type: avg
+        direction: 1
+        threshold: 10

--- a/scripts/queries/netobserv-orion-node-density-heavy.yaml
+++ b/scripts/queries/netobserv-orion-node-density-heavy.yaml
@@ -1,12 +1,12 @@
 tests:
-  - name: netobserv-perf-node-density-heavy-{{ platform }}-{{ workers }}w
+  - name: netobserv-perf-node-density-heavy-AWS-{{ workers }}w
     index: perf_scale_ci*
     benchmarkIndex: prod-netobserv-datapoints*
     metadata:
       benchmark.keyword: node-density-heavy
-      platform: {{ platform }}
+      platform: AWS
       workerNodesCount: {{ workers }}
-      ocpVersion: {{ version }}
+      ocpVersion: 4
       jobType: periodic
     metrics:
       - name: nFlowsProcessedTotals


### PR DESCRIPTION
[NETOBSERV-2034](https://issues.redhat.com//browse/NETOBSERV-2034)  Netobserv orion configs

Using `threshold` same as currently defined in touchstone. The `direction` config is defined as:

```
direction: 1 specifies to show positive changes
direction: 0 specifies to show both positive and negative changes
direction: -1 shows negative changes
```

Read more about `orion` [here](https://github.com/cloud-bulldozer/orion/?tab=readme-ov-file#direction)