### PR TITLE
Reapply "Netobserv: track metrics cardinality (#760)" (#765)

### DIFF
--- a/scripts/queries/netobserv-orion-cluster-density-v2-ospst.yaml
+++ b/scripts/queries/netobserv-orion-cluster-density-v2-ospst.yaml
@@ -181,6 +181,24 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 60
+      - name: metricsCardinality
+        metric_name: metricsCardinality
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: metrics_cardinality
+          agg_type: avg
+        direction: 0
+        threshold: 30
+      - name: flpMetricsCardinality
+        metric_name: flpMetricsCardinality
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_metrics_cardinality
+          agg_type: avg
+        direction: 0
+        threshold: 30
       - name: TotalNetObservCPUUsage
         metric_name: TotalNetObservCPUUsage
         timestamp: iso_timestamp

--- a/scripts/queries/netobserv-orion-cluster-density-v2.yaml
+++ b/scripts/queries/netobserv-orion-cluster-density-v2.yaml
@@ -181,6 +181,24 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 60
+      - name: metricsCardinality
+        metric_name: metricsCardinality
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: metrics_cardinality
+          agg_type: avg
+        direction: 0
+        threshold: 30
+      - name: flpMetricsCardinality
+        metric_name: flpMetricsCardinality
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_metrics_cardinality
+          agg_type: avg
+        direction: 0
+        threshold: 30
       - name: TotalNetObservCPUUsage
         metric_name: TotalNetObservCPUUsage
         timestamp: iso_timestamp

--- a/scripts/queries/netobserv-orion-node-density-heavy-ospst.yaml
+++ b/scripts/queries/netobserv-orion-node-density-heavy-ospst.yaml
@@ -181,6 +181,24 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 60
+      - name: metricsCardinality
+        metric_name: metricsCardinality
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: metrics_cardinality
+          agg_type: avg
+        direction: 0
+        threshold: 30
+      - name: flpMetricsCardinality
+        metric_name: flpMetricsCardinality
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_metrics_cardinality
+          agg_type: avg
+        direction: 0
+        threshold: 30
       - name: TotalNetObservCPUUsage
         metric_name: TotalNetObservCPUUsage
         timestamp: iso_timestamp

--- a/scripts/queries/netobserv-orion-node-density-heavy.yaml
+++ b/scripts/queries/netobserv-orion-node-density-heavy.yaml
@@ -181,6 +181,24 @@ tests:
           agg_type: avg
         direction: 1
         threshold: 60
+      - name: metricsCardinality
+        metric_name: metricsCardinality
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: metrics_cardinality
+          agg_type: avg
+        direction: 0
+        threshold: 30
+      - name: flpMetricsCardinality
+        metric_name: flpMetricsCardinality
+        timestamp: iso_timestamp
+        metric_of_interest: value
+        agg:
+          value: flp_metrics_cardinality
+          agg_type: avg
+        direction: 0
+        threshold: 30
       - name: TotalNetObservCPUUsage
         metric_name: TotalNetObservCPUUsage
         timestamp: iso_timestamp

--- a/scripts/queries/netobserv_prometheus_queries.yaml
+++ b/scripts/queries/netobserv_prometheus_queries.yaml
@@ -202,6 +202,18 @@
 - query: sum(container_memory_working_set_bytes{namespace="netobserv", container="", pod=~"kafka.*"})
   metricName: workingsetKafkaTotals
 
+######################
+# Prometheus metrics #
+######################
+
+# netobserv total metrics cardinality ingested in Prometheus
+- query: count({__name__=~"netobserv_.*"})
+  metricName: metricsCardinality
+
+# FLP metrics cardinality ingested in Prometheus
+- query: count({__name__=~"netobserv_.*",job="flowlogs-pipeline-prom"})
+  metricName: flpMetricsCardinality
+
 ###########################
 # Total metrics #
 ###########################

--- a/scripts/queries/netobserv_prometheus_queries.yaml
+++ b/scripts/queries/netobserv_prometheus_queries.yaml
@@ -202,16 +202,16 @@
 - query: sum(container_memory_working_set_bytes{namespace="netobserv", container="", pod=~"kafka.*"})
   metricName: workingsetKafkaTotals
 
-######################
-# Prometheus metrics #
-######################
+#######################
+# Metrics Cardinality #
+#######################
 
 # netobserv total metrics cardinality ingested in Prometheus
-- query: count({__name__=~"netobserv_.*"})
+- query: sum(scrape_samples_post_metric_relabeling{job=~"flowlogs-pipeline-prom|flowlogs-pipeline-transformer-prom|ebpf-agent-svc-prom"})
   metricName: metricsCardinality
 
 # FLP metrics cardinality ingested in Prometheus
-- query: count({__name__=~"netobserv_.*",job="flowlogs-pipeline-prom"})
+- query: sum(scrape_samples_post_metric_relabeling{job="flowlogs-pipeline-prom"})
   metricName: flpMetricsCardinality
 
 ###########################

--- a/scripts/queries/netobserv_touchstone_statistics_config.json
+++ b/scripts/queries/netobserv_touchstone_statistics_config.json
@@ -840,6 +840,32 @@
             },
             {
                 "filter": {
+                    "metric_name.keyword": "metricsCardinality"
+                },
+                "buckets": [
+                    "metric_name.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "flpMetricsCardinality"
+                },
+                "buckets": [
+                    "metric_name.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
                     "metric_name.keyword": "TotalNetObservCPUUsage"
                 },
                 "buckets": [

--- a/scripts/queries/netobserv_touchstone_tolerancy_config.json
+++ b/scripts/queries/netobserv_touchstone_tolerancy_config.json
@@ -350,6 +350,19 @@
             },
             {
                 "filter": {
+                    "metric_name.keyword": "metricsCardinality"
+                },
+                "buckets": [
+                    "metric_name.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
                     "metric_name.keyword": "TotalNetObservCPUUsage"
                 },
                 "buckets": [

--- a/scripts/queries/netobserv_touchstone_tolerancy_rules.yaml
+++ b/scripts/queries/netobserv_touchstone_tolerancy_rules.yaml
@@ -61,6 +61,9 @@
 - json_path: ["metric_name", "rssPrometheusTotals", "metric_name", "*", "avg(value)"]
   tolerancy: 60
   max_failures: 0
+- json_path: ["metric_name", "metricsCardinality", "metric_name", "*", "avg(value)"]
+  tolerancy: 30
+  max_failures: 0
 # total usages
 - json_path: ["metric_name", "TotalNetObservCPUUsage", "metric_name", "*", "avg(value)"]
   tolerancy: 10


### PR DESCRIPTION
This reverts commit 802349789c639347816da2ce47c07fc7c4cbe4cc.

@memodi , I'd like to revisit adding metrics cardinality as this is something important to know when tracking down potential regressions. I will bring some changes that I hope will fix the issue that you saw - and if it doesn't, we should try to investigate/refine on live cluster, if possible, rather than reverting?